### PR TITLE
feat(useLoading): 增强 loading 显隐逻辑

### DIFF
--- a/packages/hooks/src/useLoading/index.ts
+++ b/packages/hooks/src/useLoading/index.ts
@@ -1,5 +1,5 @@
-import { showLoading, hideLoading } from '@tarojs/taro';
-import { useCallback, useEffect, useRef } from 'react';
+import { showLoading, hideLoading, getCurrentInstance } from '@tarojs/taro';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 export interface LoadingOption {
   title: string;
@@ -11,10 +11,33 @@ export type ShowLoading = (
 ) => Promise<TaroGeneral.CallbackResult>;
 export type HideLoading = () => Promise<TaroGeneral.CallbackResult>;
 
+const useLoadingPageRecord: Record<string, Set<number> | undefined> = {};
+const USE_LOADING_MAX_COUNT = 0b11111111;
+let useLoadingCount = 0;
+
 function useLoading(
   option?: Partial<LoadingOption>,
 ): [ShowLoading, HideLoading] {
   const initialOption = useRef<Partial<LoadingOption>>();
+  const pageKey = useMemo(
+    () => (getCurrentInstance().page as any)?.$taroPath,
+    [],
+  );
+  const loadingKey = useMemo(() => {
+    useLoadingCount++;
+    if (useLoadingCount > USE_LOADING_MAX_COUNT) {
+      useLoadingCount = 0;
+    }
+    return useLoadingCount;
+  }, []);
+
+  useEffect(() => {
+    useLoadingPageRecord[pageKey] = new Set();
+    return () => {
+      useLoadingPageRecord[pageKey] = undefined;
+      hideLoading();
+    };
+  }, [pageKey]);
 
   useEffect(() => {
     initialOption.current = option;
@@ -22,6 +45,7 @@ function useLoading(
 
   const showLoadingAsync = useCallback<ShowLoading>(
     (option) => {
+      useLoadingPageRecord[pageKey]?.add(loadingKey);
       return new Promise((resolve, reject) => {
         try {
           if (!option && !initialOption.current) {
@@ -48,10 +72,17 @@ function useLoading(
         }
       });
     },
-    [initialOption],
+    [initialOption, loadingKey, pageKey],
   );
 
   const hideLoadingAsync = useCallback<HideLoading>(() => {
+    const pageRecord = useLoadingPageRecord[pageKey];
+    if (pageRecord) {
+      pageRecord.delete(loadingKey);
+      if (pageRecord.size > 0) {
+        return Promise.resolve({ errMsg: 'hideLoading:ok' });
+      }
+    }
     return new Promise((resolve, reject) => {
       try {
         hideLoading({
@@ -62,7 +93,7 @@ function useLoading(
         reject(e);
       }
     });
-  }, []);
+  }, [loadingKey, pageKey]);
 
   return [showLoadingAsync, hideLoadingAsync];
 }


### PR DESCRIPTION
![Completed](https://badgen.net/badge/Setup/Completed/green) ![128](https://badgen.net/badge/Description%20length/128/green) ![main](https://badgen.net/badge/Branch/main/red) ![Enside](https://badgen.net/badge/Contributor/Enside/blue) ![1](https://badgen.net/badge/ChangeFiles/1/orange) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=innocces&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

业务中同一个页面拆分的不同组件中，可能都有用到 useLoading，但是只要任意组件中调用了 hideLoading，那么整个页面都没有 loading 动画了。

我基于 useLoading 封装了一层计数，只有当整个页面计数清零时才会真正隐藏。